### PR TITLE
getMaxLines() count the wrapped lines.

### DIFF
--- a/examples/chatbox/ui/Textarea.lua
+++ b/examples/chatbox/ui/Textarea.lua
@@ -610,10 +610,24 @@ end
 
 function Textarea:getMaxLines()
     local n_lines = 0
+    --added
+    local count = 0
+    
     for i, c in ipairs(self.line_text) do
+        --count characters...
+        count = count+1
+        
         if c.character ~= '\n' then
             n_lines = c.line + 1
         end
+        
+        --if characters are bigger the wrap width...
+        if count >= self.text.wrap_width then
+           --...count the wraped lines
+           n_lines = c.line + 1
+           count = 0
+        end
+        
     end
     return n_lines
 end

--- a/ui/Textarea.lua
+++ b/ui/Textarea.lua
@@ -610,9 +610,21 @@ end
 
 function Textarea:getMaxLines()
     local n_lines = 0
+    --added
+    local count = 0
     for i, c in ipairs(self.line_text) do
+        --count characters...
+        count = count+1
+        
         if c.character ~= '\n' then
             n_lines = c.line + 1
+        end
+        
+        --if characters are bigger the wrap width...
+        if count >= self.text.wrap_width then
+           --...count the wrapped lines
+           n_lines = c.line + 1
+           count = 0
         end
     end
     return n_lines


### PR DESCRIPTION
I was playing around the Chatbox example.
The long lines, the wrapped ones, were count like they were one only line, making the scroll don't worked right.
This fixed it, but I believe this can have make troubles if someone don't want to count the wrapped lines. Maybe adding a new function.